### PR TITLE
[WIP] Fix MonitoringSlo Read

### DIFF
--- a/google/resource_monitoring_slo.go
+++ b/google/resource_monitoring_slo.go
@@ -894,6 +894,9 @@ func resourceMonitoringSloRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("slo_id", flattenMonitoringSloSloId(res["name"], d, config)); err != nil {
 		return fmt.Errorf("Error reading Slo: %s", err)
 	}
+	if err := d.Set("service", flattenMonitoringSloService(res["name"], d, config)); err != nil {
+		return fmt.Errorf("Error reading Service: %s", err)
+	}
 
 	return nil
 }
@@ -1582,6 +1585,14 @@ func flattenMonitoringSloSloId(v interface{}, d *schema.ResourceData, config *Co
 		return v
 	}
 	return NameFromSelfLinkStateFunc(v)
+}
+
+func flattenMonitoringSloService(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	if v == nil {
+		return v
+	}
+	parts := strings.Split(v.(string), "/")
+	return parts[len(parts)-3]
 }
 
 func expandMonitoringSloDisplayName(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {

--- a/google/resource_monitoring_slo_test.go
+++ b/google/resource_monitoring_slo_test.go
@@ -69,6 +69,25 @@ func getTestResourceMonitoringSloId(res string, s *terraform.State) (string, err
 	return "", fmt.Errorf("slo_id not set on resource %s", res)
 }
 
+func TestFlattenMonitoringSloService(t *testing.T) {
+	cases := map[string]struct {
+		Name            interface{}
+		ExpectedService string
+	}{
+		"service is extracted from name": {
+			// https://cloud.google.com/monitoring/api/ref_v3/rest/v3/services.serviceLevelObjectives/get#path-parameters
+			Name:            "projects/PROJECT_ID_OR_NUMBER/services/SERVICE_ID/serviceLevelObjectives/SLO_NAME",
+			ExpectedService: "SERVICE_ID",
+		},
+	}
+
+	for tn, tc := range cases {
+		if n := flattenMonitoringSloService(tc.Name, nil, nil); n != tc.ExpectedService {
+			t.Errorf("%s: expected service %q; got %q", tn, tc.ExpectedService, n)
+		}
+	}
+}
+
 func TestAccMonitoringSlo_basic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Description
Fixed a problem that the service field was null when importing google_monitoring_slo.
The current version of terraform-provider-google was implemented in such a way that the value of service was null when importing google_monitoring_slo, and it was regenerated when the apply was executed.
In this PR, the service value is changed to be set when import is executed.

# OAT

Before 

```
$ terraform import -state=tmp.tfstate google_monitoring_custom_service.hoge CUSTOM_SERVICE_ID
google_monitoring_custom_service.hoge: Importing from ID "CUSTOM_SERVICE_ID"...
google_monitoring_custom_service.hoge: Import prepared!
  Prepared google_monitoring_custom_service for import
google_monitoring_custom_service.hoge: Refreshing state... [id=CUSTOM_SERVICE_ID]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

$ terraform import -state=tmp.tfstate google_monitoring_slo.hoge SLO_ID
google_monitoring_slo.hoge: Importing from ID "SLO_ID"...
google_monitoring_slo.hoge: Import prepared!
  Prepared google_monitoring_slo for import
google_monitoring_slo.hoge: Refreshing state... [id=SLO_ID]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

$ cat tmp.tfstate
{
  "version": 4,
  "terraform_version": "1.1.7",
  "serial": 2,
  "lineage": "503a2f57-8b7a-fbc9-b0a1-82e860b46776",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "google_monitoring_custom_service",
      "name": "hoge",
      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "display_name": "SERVICE_ID",
            "id": "CUSTOM_SERVICE_ID",
            "name": "CUSTOM_SERVICE_ID",
            "project": "PROJECT_ID",
            "service_id": "SERVICE_ID",
            "telemetry": [],
            "timeouts": {
              "create": null,
              "delete": null,
              "update": null
            }
          },
          "sensitive_attributes": [],
          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMCJ9"
        }
      ]
    },
    {
      "mode": "managed",
      "type": "google_monitoring_slo",
      "name": "hoge",
      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "basic_sli": [],
            "calendar_period": "WEEK",
            "display_name": "hoge",
            "goal": 0.8,
            "id": "SLO_ID",
            "name": "SLO_ID",
            "project": "PROJECT_ID",
            "request_based_sli": [
              {
                "distribution_cut": [
                  {
                    distribution_filter = "metric.type=\"serviceruntime.googleapis.com/api/request_latencies\" resource.type=\"api\"  "
                    "range": [
                      {
                        "max": 10,
                        "min": 0
                      }
                    ]
                  }
                ],
                "good_total_ratio": []
              }
            ],
            "rolling_period_days": 0,
            "service": null,
            "slo_id": "SERVICE_ID-hoge",
            "timeouts": {
              "create": null,
              "delete": null,
              "update": null
            },
            "windows_based_sli": []
          },
          "sensitive_attributes": [],
          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMCJ9"
        }
      ]
    }
  ]
}

$ terraform plan -state=tmp.tfstate
google_monitoring_custom_service.hoge: Refreshing state... [id=CUSTOM_SERVICE_ID]
google_monitoring_slo.hoge: Refreshing state... [id=SLO_ID]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # google_monitoring_slo.hoge must be replaced
-/+ resource "google_monitoring_slo" "hoge" {
      ~ id                  = "SLO_ID" -> (known after apply)
      ~ name                = "SLO_ID" -> (known after apply)
      ~ project             = "PROJECT_ID" -> (known after apply)
      - rolling_period_days = 0 -> null
      + service             = "SERVICE_ID" # forces replacement
        # (4 unchanged attributes hidden)


      - timeouts {}
        # (1 unchanged block hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

After 

```
$ terraform import -state=tmp.tfstate google_monitoring_custom_service.hoge CUSTOM_SERVICE_ID
google_monitoring_custom_service.hoge: Importing from ID "CUSTOM_SERVICE_ID"...
google_monitoring_custom_service.hoge: Import prepared!
  Prepared google_monitoring_custom_service for import
google_monitoring_custom_service.hoge: Refreshing state... [id=CUSTOM_SERVICE_ID]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

$ terraform import -state=tmp.tfstate google_monitoring_slo.hoge SLO_ID
google_monitoring_slo.hoge: Importing from ID "SLO_ID"...
google_monitoring_slo.hoge: Import prepared!
  Prepared google_monitoring_slo for import
google_monitoring_slo.hoge: Refreshing state... [id=SLO_ID]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

$ cat tmp.tfstate
{
  "version": 4,
  "terraform_version": "1.1.7",
  "serial": 2,
  "lineage": "a1ab70dd-8283-420a-a6ac-4ec2afbcdfb4",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "google_monitoring_custom_service",
      "name": "hoge",
      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "display_name": "SERVICE_ID",
            "id": "CUSTOM_SERVICE_ID",
            "name": "CUSTOM_SERVICE_ID",
            "project": "PROJECT_ID",
            "service_id": "SERVICE_ID",
            "telemetry": [],
            "timeouts": {
              "create": null,
              "delete": null,
              "update": null
            }
          },
          "sensitive_attributes": [],
          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMCJ9"
        }
      ]
    },
    {
      "mode": "managed",
      "type": "google_monitoring_slo",
      "name": "hoge",
      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "basic_sli": [],
            "calendar_period": "WEEK",
            "display_name": "hoge",
            "goal": 0.8,
            "id": "SLO_ID",
            "name": "SLO_ID",
            "project": "PROJECT_ID",
            "request_based_sli": [
              {
                "distribution_cut": [
                  {
                    distribution_filter = "metric.type=\"serviceruntime.googleapis.com/api/request_latencies\" resource.type=\"api\"  "
                    "range": [
                      {
                        "max": 10,
                        "min": 0
                      }
                    ]
                  }
                ],
                "good_total_ratio": []
              }
            ],
            "rolling_period_days": 0,
            "service": "SERVICE_ID",
            "slo_id": "SERVICE_ID-latency-slo",
            "timeouts": {
              "create": null,
              "delete": null,
              "update": null
            },
            "windows_based_sli": []
          },
          "sensitive_attributes": [],
          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMCJ9"
        }
      ]
    }
  ]
}
$ terraform plan -state=tmp.tfstate
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/google in nyuta/google
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
google_monitoring_custom_service.hoge: Refreshing state... [id=CUSTOM_SERVICE_ID]
google_monitoring_slo.hoge: Refreshing state... [id=SLO_ID]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```
